### PR TITLE
Optional client-hostname

### DIFF
--- a/dhcpd_lease_exporter.py
+++ b/dhcpd_lease_exporter.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from prometheus_client import start_http_server, write_to_textfile
 from prometheus_client import REGISTRY, CollectorRegistry, Gauge, Counter
 
-PATTERN = r"lease ([0-9.]+) {.*?starts \d (.*?);.*?ends \d (.*?);.*?hardware ethernet ([:a-f0-9]+);.*?client-hostname \"(.*?)\";.*?}"
+PATTERN = r"lease ([0-9.]+) {.*?starts \d (.*?);.*?ends \d (.*?);.*?hardware ethernet ([:a-f0-9]+);.*?(client-hostname \"(.*?)\";.*?)?}"
 REGEX = re.compile(PATTERN, re.MULTILINE | re.DOTALL)
 DEFAULT_PREFIX = "dhcpd_leases"
 
@@ -118,7 +118,7 @@ class DhcpdLeasesExporter:
                 starts = DhcpdLeasesExporter.parse_date(match.group(2))
                 ends = DhcpdLeasesExporter.parse_date(match.group(3))
 
-                lease = Lease(ip_addr=match.group(1), mac=match.group(4), name=match.group(5), starts=starts, ends=ends)
+                lease = Lease(ip_addr=match.group(1), mac=match.group(4), name=match.group(6), starts=starts, ends=ends)
 
                 ends_unix = lease.ends.strftime("%s")
                 self._metric_lease_end.labels(lease.mac, lease.ip_addr, lease.name).set(ends_unix)


### PR DESCRIPTION
```shell
$ dhcpd --version
isc-dhcpd-4.4.3-P1
```

A leases file can have entries without `client-hostname`.

Example:

```
ease 10.0.255.49 {
  starts 0 2023/03/05 23:21:15 EST;
  ends 0 2023/03/05 23:39:27 EST;
  tstp 0 2023/03/05 23:39:27 EST;
  cltt 0 2023/03/05 23:21:15 EST;
  binding state free;
  hardware ethernet 4c:a1:41:41:13:a2;
  uid "\001L\253OA\023\243";
}
lease 10.0.255.53 {
  starts 1 2023/03/06 02:37:06 EST;
  ends 1 2023/03/06 02:47:06 EST;
  tstp 1 2023/03/06 02:47:06 EST;
  cltt 1 2023/03/06 02:37:06 EST;
  binding state free;
  hardware ethernet a0:d2:b2:f8:4c:c1;
  uid "\001\240\322\261\370l\303";
  set vendor-class-identifier = "udhcp 1.28.3";
}
lease 10.0.255.54 {
  starts 1 2023/03/06 02:42:11 EST;
  ends 1 2023/03/06 02:52:11 EST;
  tstp 1 2023/03/06 02:52:11 EST;
  cltt 1 2023/03/06 02:42:11 EST;
  binding state active;
  next binding state free;
  rewind binding state free;
  hardware ethernet a8:11:39:62:f2:3a;
  uid "\001\250\241Yb\372>";
  set vendor-class-identifier = "MSFT 5.0";
  client-hostname "DESKTOP";
}
```

The regex used in the script would take the `hardware ethernet` from the first lease (`4c:a1:41:41:13:a2`) and then capture with `.*` until it eventually finds a `client-hostname`. However, we have now squashed three leases together and an incorrect pair of MAC address and hostname (`4c:a1:41:41:13:a2` -> `DESKTOP`).

This PR makes the hostname optional and converts to `None` if the hostname is unknown.